### PR TITLE
Fixes list_params to use 'order' instead of 'oder'

### DIFF
--- a/samples/alertV2/list.js
+++ b/samples/alertV2/list.js
@@ -17,7 +17,7 @@ var list_params = {
     offset : 0,
     limit : 10,
     sort : "alias",
-    oder : "desc"
+    order : "desc"
 };
 
 opsgenie.alertV2.list(list_params, function (error, alerts) {


### PR DESCRIPTION
Fixed a slight misspelling in the alertV2/list example.